### PR TITLE
[IIIF-699] EKS work to use Terraform 0.12.20

### DIFF
--- a/.travis/terraform-validate.sh
+++ b/.travis/terraform-validate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Module terraform validate script
 
-TERRAFORM_VERSION="0.12.5"
+TERRAFORM_VERSION="0.12.20"
 TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 TERRAFORM_BIN="${HOME}/terraform/bin"
 TERRAFORM="${TERRAFORM_BIN}/terraform"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "sg" {
-  name          = "${var.sg_name}"
-  description   = "${var.sg_description}"
-  vpc_id        = "${var.vpc_id}"
+  name          = var.sg_name
+  description   = var.sg_description
+  vpc_id        = var.vpc_id
 
   dynamic ingress {
     for_each = var.ingress_ports
@@ -9,8 +9,8 @@ resource "aws_security_group" "sg" {
       from_port       = ingress.value
       to_port         = ingress.value
       protocol        = "tcp"
-      cidr_blocks     = "${var.ingress_allowed}"
-      security_groups = "${var.sg_groups}"
+      cidr_blocks     = var.ingress_allowed
+      security_groups = var.sg_groups
     }
   }
 
@@ -21,4 +21,3 @@ resource "aws_security_group" "sg" {
     cidr_blocks     = ["0.0.0.0/0"]
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 resource "aws_security_group" "sg" {
-  name          = var.sg_name
-  description   = var.sg_description
-  vpc_id        = var.vpc_id
+  name                = var.sg_name
+  description         = var.sg_description
+  vpc_id              = var.vpc_id
 
   dynamic ingress {
-    for_each = var.ingress_ports
+    for_each          = var.ingress_ports
     content {
       from_port       = ingress.value
       to_port         = ingress.value
@@ -15,9 +15,13 @@ resource "aws_security_group" "sg" {
   }
 
   egress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    cidr_blocks     = ["0.0.0.0/0"]
+    from_port         = 0
+    to_port           = 0
+    protocol          = "-1"
+    cidr_blocks       = ["0.0.0.0/0"]
+  }
+
+  tags                = {
+    Name              = var.default_tag
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,3 @@
 output "id" {
-  value = "${aws_security_group.sg.id}"
+  value = aws_security_group.sg.id
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,9 @@ variable "sg_description" {}
 variable "vpc_id" {}
 variable "ingress_ports" {}
 variable "ingress_allowed" {
-    default = ["0.0.0.0/0"]
+  default = ["0.0.0.0/0"]
 }
+
 variable "sg_groups" {
-    default = null
+  default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,9 @@ variable "sg_name" {}
 variable "sg_description" {}
 variable "vpc_id" {}
 variable "ingress_ports" {}
-variable "ingress_allowed" { default = ["0.0.0.0/0"] }
-variable "sg_groups" { default = null }
-
+variable "ingress_allowed" {
+    default = ["0.0.0.0/0"]
+}
+variable "sg_groups" {
+    default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,7 @@ variable "ingress_allowed" {
 variable "sg_groups" {
   default = null
 }
+
+variable "default_tag" {
+  default = "SG-Terraform"
+}


### PR DESCRIPTION
The new EKS environment will be deployed usingTerraform 0.12.20. It looks like interpolation only expressions are being deprecated.

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/allow_http_https_ingress/main.tf line 2, in resource "aws_security_group" "sg":
   2:   name          = "${var.sg_name}"

```